### PR TITLE
CI Updates

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,16 @@
+name: test
+
+on:
+  push:
+
+jobs:
+  jest:
+    name: jest
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-node@v3
+      with:
+        node-version: 16
+    - run: npm ci
+    - run: npm test

--- a/__tests__/helpers.ts
+++ b/__tests__/helpers.ts
@@ -1,4 +1,5 @@
 import * as fs from 'fs/promises'
+import * as core from '@actions/core'
 import path from 'path'
 
 export const testFixturesDirectory = path.join(__dirname, 'fixtures')
@@ -19,7 +20,7 @@ module github.com/robherley/go-test-example
 go 1.18
 `
 
-export const setupActionsInputs = async () => {
+export const setupActionsInputs = () => {
   process.env['INPUT_MODULEDIRECTORY'] = testModuleDirectory
   process.env['INPUT_TESTARGUMENTS'] = testArguments
 }
@@ -45,4 +46,21 @@ export const getTestStdout = async (): Promise<string> => {
     path.join(testFixturesDirectory, 'gotestoutput.txt')
   )
   return buf.toString()
+}
+
+export const mockActionsCoreLogging = () => {
+  type LogFuncs = 'debug' | 'error' | 'warning' | 'notice' | 'info'
+  const logMethods: LogFuncs[] = ['debug', 'error', 'warning', 'notice', 'info']
+  logMethods.forEach(method => {
+    jest
+      .spyOn(core, method)
+      .mockImplementation(
+        (msg: string | Error, props?: core.AnnotationProperties) => {
+          console.log(
+            `[mock: core.${method}(${props ? JSON.stringify(props) : ''})]:`,
+            msg
+          )
+        }
+      )
+  })
 }

--- a/__tests__/renderer.test.ts
+++ b/__tests__/renderer.test.ts
@@ -1,7 +1,11 @@
-import { getTestStdout } from './helpers'
+import { getTestStdout, mockActionsCoreLogging } from './helpers'
 import Renderer from '../src/renderer'
 
 describe('Renderer', () => {
+  beforeEach(async () => {
+    mockActionsCoreLogging()
+  })
+
   it('correctly parses test2json output', async () => {
     const stdout = await getTestStdout()
 

--- a/__tests__/tester.test.ts
+++ b/__tests__/tester.test.ts
@@ -8,6 +8,7 @@ import {
   testModuleDirectory,
   mockProcessExit,
   createFakeGoModule,
+  mockActionsCoreLogging,
 } from './helpers'
 import Tester from '../src/tester'
 import Renderer from '../src/renderer'
@@ -18,7 +19,8 @@ describe('Tester', () => {
   })
 
   beforeEach(async () => {
-    await setupActionsInputs()
+    mockActionsCoreLogging()
+    setupActionsInputs()
   })
 
   it("sets defaults if inputs aren't set", async () => {

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,6 +1,0 @@
-/** @type {import('ts-jest/dist/types').InitialOptionsTsJest} */
-module.exports = {
-  preset: 'ts-jest',
-  testEnvironment: 'node',
-  testPathIgnorePatterns: ['helpers.ts'],
-}

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -5,6 +5,7 @@ const config: Config.InitialOptions = {
   testEnvironment: 'node',
   testPathIgnorePatterns: ['helpers.ts'],
   reporters: ['default', 'github-actions'],
+  clearMocks: true,
 }
 
 export default config

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,0 +1,10 @@
+import type { Config } from '@jest/types'
+
+const config: Config.InitialOptions = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  testPathIgnorePatterns: ['helpers.ts'],
+  reporters: ['default', 'github-actions'],
+}
+
+export default config


### PR DESCRIPTION
- `jest.config.js` -> `jest.config.ts`
- actions workflow to run jest tests
- mocking `core.<method>` functions: prevents random annotations from appearing during actions ci ([example](https://github.com/robherley/go-test-action/actions/runs/2679779990))